### PR TITLE
feat: add Codecov coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+source = .
+include = statusline.py
+parallel = true
+
+[report]
+include = statusline.py
+show_missing = true
+fail_under = 60
+exclude_lines =
+    pragma: no cover
+    if __name__ == "__main__"
+    debug_log
+
+[xml]
+output = coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [main, 'claude/*']
+    branches: [main, 'claude/*', 'feat/*']
   pull_request:
     branches: [main]
 
@@ -101,3 +101,36 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+          enable-cache: true
+
+      - name: Run tests with coverage
+        run: uv run --with coverage python test_statusline.py
+        env:
+          PYTHONUTF8: "1"
+          COVERAGE_MODE: "1"
+
+      - name: Combine coverage data
+        run: uv run --with coverage coverage combine
+
+      - name: Generate coverage reports
+        run: |
+          uv run --with coverage coverage report
+          uv run --with coverage coverage xml
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ ecw-statusline-state.json
 *.log
 *.tmp
 .coverage
+.coverage.*
+coverage.xml
 htmlcov/
 .pytest_cache/
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ECW Status Line
 
 [![Tests](https://github.com/geekatron/jerry-statusline/actions/workflows/test.yml/badge.svg)](https://github.com/geekatron/jerry-statusline/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/geekatron/jerry-statusline/graph/badge.svg)](https://codecov.io/gh/geekatron/jerry-statusline)
 
 **Evolved Claude Workflow** - A single-file, self-contained status line for Claude Code providing maximum visibility into session state, resource consumption, and workspace context. Integrates with [Jerry Framework](https://github.com/geekatron/jerry) for domain-computed context monitoring.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 60%
+        threshold: 5%
+    patch:
+      default:
+        target: 70%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default

--- a/test_statusline.py
+++ b/test_statusline.py
@@ -247,6 +247,13 @@ SAMPLE_TRANSCRIPT = [
 # =============================================================================
 
 
+def _build_cmd() -> list:
+    """Build the command to run statusline.py, optionally with coverage instrumentation."""
+    if os.environ.get("COVERAGE_MODE"):
+        return [sys.executable, "-m", "coverage", "run", "--parallel-mode", str(STATUSLINE_SCRIPT)]
+    return [sys.executable, str(STATUSLINE_SCRIPT)]
+
+
 def run_test(name: str, payload: dict, config_override: dict = None) -> bool:
     """Run statusline script with payload and display result."""
     print(f"\n{'=' * 60}")
@@ -272,7 +279,7 @@ def run_test(name: str, payload: dict, config_override: dict = None) -> bool:
 
     try:
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(payload),
             capture_output=True,
             text=True,
@@ -329,7 +336,7 @@ def run_tools_test() -> bool:
             json.dump(config, f)
 
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(payload),
             capture_output=True,
             text=True,
@@ -371,7 +378,7 @@ def run_compact_test() -> bool:
             json.dump(config, f)
 
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -418,7 +425,7 @@ def run_currency_test() -> bool:
             json.dump(config, f)
 
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -449,7 +456,7 @@ def run_tokens_segment_test() -> bool:
 
     try:
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -487,7 +494,7 @@ def run_session_segment_test() -> bool:
 
     try:
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_LONG_SESSION),
             capture_output=True,
             text=True,
@@ -542,7 +549,7 @@ def run_compaction_test() -> bool:
             json.dump(config, f)
 
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -584,7 +591,7 @@ def run_no_home_test() -> bool:
 
     try:
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -622,7 +629,7 @@ def run_no_tty_test() -> bool:
     try:
         # Run with stdin as pipe (no TTY) - this is the default for subprocess
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_MINIMAL),
             capture_output=True,
             text=True,
@@ -674,7 +681,7 @@ def run_readonly_state_test() -> bool:
             json.dump(config, f)
 
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -724,7 +731,7 @@ def run_emoji_disabled_test() -> bool:
             json.dump(config, f)
 
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -786,7 +793,7 @@ def run_corrupt_state_test() -> bool:
             json.dump(config, f)
 
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -835,7 +842,7 @@ def run_no_color_env_test() -> bool:
 
     try:
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -898,7 +905,7 @@ def run_use_color_disabled_test() -> bool:
             json.dump(config, f)
 
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -1008,7 +1015,7 @@ def run_color_matrix_test() -> bool:
                 json.dump(config, f)
 
             result = subprocess.run(
-                [sys.executable, str(STATUSLINE_SCRIPT)],
+                _build_cmd(),
                 input=json.dumps(PAYLOAD_NORMAL),
                 capture_output=True,
                 text=True,
@@ -1085,7 +1092,7 @@ def run_atomic_write_test() -> bool:
 
         # Run 1: Establish state (first run writes state atomically)
         result1 = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -1125,7 +1132,7 @@ def run_atomic_write_test() -> bool:
         # Run 2: With high previous context, should detect compaction
         # (proves state was written correctly and can be read back)
         result2 = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -1245,7 +1252,7 @@ def run_schema_version_in_state_test() -> bool:
 
         # Run the script to trigger state save
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -1306,7 +1313,7 @@ def run_schema_version_mismatch_warning_test() -> bool:
             json.dump(config, f)
 
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -1367,7 +1374,7 @@ def run_unversioned_config_backward_compat_test() -> bool:
             json.dump(config, f)
 
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,
@@ -1455,7 +1462,7 @@ def run_schema_version_match_no_warning_test() -> bool:
             json.dump(config, f)
 
         result = subprocess.run(
-            [sys.executable, str(STATUSLINE_SCRIPT)],
+            _build_cmd(),
             input=json.dumps(PAYLOAD_NORMAL),
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary
- Add code coverage collection via `coverage.py` that works with the subprocess-based test runner
- Introduce `_build_cmd()` helper in `test_statusline.py` that optionally instruments `statusline.py` via `coverage run --parallel-mode` when `COVERAGE_MODE=1`
- Add dedicated coverage job to GitHub Actions workflow with Codecov upload
- Add `feat/*` branch trigger to CI workflow

## Files
| File | Change |
|------|--------|
| `.coveragerc` | New — coverage config (parallel mode, scoped to statusline.py, 60% threshold) |
| `codecov.yml` | New — Codecov reporting config (60% project / 70% patch targets) |
| `test_statusline.py` | Add `_build_cmd()` helper, replace 21 subprocess calls |
| `.github/workflows/test.yml` | Add coverage job + `feat/*` branch trigger |
| `README.md` | Add Codecov badge |
| `.gitignore` | Add `.coverage.*` and `coverage.xml` patterns |

## Verification
- 27/27 tests pass without coverage mode (no regression)
- 27/27 tests pass with `COVERAGE_MODE=1`
- `statusline.py` line coverage: **75%** (above 60% threshold)
- `coverage.xml` generated successfully

## Prerequisites
- Codecov needs to be enabled for the `geekatron/jerry-statusline` repo
- For public repos, no token needed — Codecov auto-discovers public GitHub repos

## Test plan
- [ ] CI coverage job runs successfully
- [ ] Codecov upload succeeds
- [ ] Codecov dashboard shows coverage for `statusline.py`
- [ ] Badge renders on README

🤖 Generated with [Claude Code](https://claude.com/claude-code)